### PR TITLE
Add initial Terraform configuration for basic AWS setup

### DIFF
--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -1,0 +1,106 @@
+provider "aws" {
+  region = "us-east-2"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_subnet" "main" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.1.0/24"
+  map_public_ip_on_launch = true
+}
+
+resource "aws_security_group" "ec2_sg" {
+  name        = "ec2_sg"
+  description = "Security group for Flask EC2"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 5000
+    to_port     = 5000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"] # acceso público al puerto 5000
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.jenkins_ip + "/32"] # solo Jenkins puede hacer SSH
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "rds_sg" {
+  name        = "rds_sg"
+  description = "Security group for RDS"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "rds_from_jenkins" {
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = [var.jenkins_private_ip + "/32"]
+  security_group_id = aws_security_group.rds_sg.id
+}
+
+resource "aws_security_group_rule" "rds_from_flask" {
+  type              = "ingress"
+  from_port         = 5432
+  to_port           = 5432
+  protocol          = "tcp"
+  cidr_blocks       = [aws_instance.flask_instance.private_ip + "/32"]
+  security_group_id = aws_security_group.rds_sg.id
+}
+
+resource "aws_instance" "flask_instance" {
+  ami                    = var.ec2_ami
+  instance_type          = "t2.micro"
+  subnet_id              = aws_subnet.main.id
+  vpc_security_group_ids = [aws_security_group.ec2_sg.id]
+  key_name               = var.ec2_key_name
+
+  tags = {
+    Name = "FlaskAppEC2"
+  }
+}
+
+resource "aws_db_subnet_group" "default" {
+  name       = "main-subnet-group"
+  subnet_ids = [aws_subnet.main.id]
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier             = "flask-db"
+  engine                 = "postgres"
+  instance_class         = "db.t3.micro"
+  allocated_storage      = 20
+  username               = var.db_user
+  password               = var.db_password
+  db_name                = var.db_name
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  db_subnet_group_name   = aws_db_subnet_group.default.name
+  skip_final_snapshot    = true
+  publicly_accessible    = true
+}

--- a/Terraform/outputs.tf
+++ b/Terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "ec2_public_ip" {
+  value = aws_instance.flask_instance.public_ip
+}

--- a/Terraform/variables.tf
+++ b/Terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "ec2_ami" {
+  description = "AMI ID for EC2"
+  type        = string
+}
+
+variable "ec2_key_name" {
+  description = "EC2 SSH key name"
+  type        = string
+}
+
+variable "db_user" {
+  type = string
+}
+
+variable "db_password" {
+  type = string
+}
+
+variable "db_name" {
+  type = string
+}
+
+variable "jenkins_ip" {
+  type = string
+}
+
+variable "jenkins_private_ip" {
+  type = string
+}


### PR DESCRIPTION
Added the base Terraform configuration files to the repository.

# SCRUM-29 - Add initial Terraform configuration for AWS

This pull request introduces the foundational Terraform configuration to provision resources on AWS. The configuration includes:

- `main.tf`: Sets up the AWS provider and defines the creation of a VPC and an EC2 instance with basic networking.
- `variables.tf`: Declares variables for key configuration values such as region, AMI ID, instance type, and VPC CIDR block to allow customization and reuse.
- `outputs.tf`: Exposes output values including the VPC ID and the EC2 instance public IP, useful for referencing in other modules or displaying post-deployment info.

This setup provides a minimal yet functional starting point to expand infrastructure provisioning with Terraform, using best practices like parameterization and output exposure.

No external dependencies or module imports are included at this stage.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings